### PR TITLE
Fix leading 0 removal for LottieBackgroundColor preference

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -22,6 +22,7 @@
         <source-file src="src/android/LottieSplashScreenExceptions.kt" target-dir="app/src/main/kotlin/de/dustplanet/cordova/lottie" />
 
         <framework src="com.airbnb.android:lottie:3.5.0" />
+        <framework src="src/android/build-aapt-extras.gradle" custom="true" type="gradleReference" />
     </platform>
 
     <platform name="ios">

--- a/src/android/build-aapt-extras.gradle
+++ b/src/android/build-aapt-extras.gradle
@@ -1,0 +1,5 @@
+android {
+    aaptOptions {
+        additionalParameters "--keep-raw-values"
+    }
+}


### PR DESCRIPTION
Hi,

I would start by saying, nice plugin :) I tried and got it worked quite easily.
I still had trouble for background color being weird on Android because of the leading 0. The problem was the same issued in your FAQ. As I would not wanted to add manually the aapt argument for each project, I added it in your plugin directly.
I'm not much into gradle and cordova as I was only using but never coding on this side. :smile: 

So I've searched a little and found this:
https://cordova.apache.org/docs/en/10.x/plugin_ref/spec.html#framework

Especially this part:

> Framework can also be used to have custom .gradle files sub-included into the main project's build.gradle file:
`<framework src="relative/path/rules.gradle" custom="true" type="gradleReference" />`.

I tried this and got it worked by just adding the plugin again.

I don't know if having this option automatically added is a good idea, just tell me if you have better idea. :)