### PR TITLE
Fix: Resolves crash in Android (webView.engine is null) with Capacitor

### DIFF
--- a/src/android/LottieSplashScreen.kt
+++ b/src/android/LottieSplashScreen.kt
@@ -272,11 +272,11 @@ class LottieSplashScreen : CordovaPlugin() {
         animationView.addAnimatorListener(
             object : Animator.AnimatorListener {
                 override fun onAnimationStart(animation: Animator) {
-                    webView.engine.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationStart'))") { }
+                    webView.engine?.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationStart'))") { }
                 }
 
                 override fun onAnimationEnd(animation: Animator) {
-                    webView.engine.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationEnd'))") { }
+                    webView.engine?.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationEnd'))") { }
                     val hideAfterAnimationDone = preferences.getBoolean(
                         "LottieHideAfterAnimationEnd",
                         false
@@ -288,11 +288,11 @@ class LottieSplashScreen : CordovaPlugin() {
                 }
 
                 override fun onAnimationCancel(animation: Animator) {
-                    webView.engine.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationCancel'))") { }
+                    webView.engine?.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationCancel'))") { }
                 }
 
                 override fun onAnimationRepeat(animation: Animator) {
-                    webView.engine.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationRepeat'))") { }
+                    webView.engine?.evaluateJavascript("document.dispatchEvent(new Event('lottieAnimationRepeat'))") { }
                 }
             }
         )


### PR DESCRIPTION
Capacitor doesn't implement `CordovaWebViewEngine` so the calls in the plugin to `webView.engine` will fail.

This PR makes the calls to `webView.engine` optional so they will fail gracefully if `webView.engine` is `null`. 

If the Capacitor team ever implements this API (see their [bug](https://github.com/ionic-team/capacitor/issues/5390)) then Lottie events will auto-magically start working.