### PR TITLE
fix: Allowing iOS Lottie version 4.4 and versions up to 5.0, not including 5.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -43,7 +43,7 @@
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods use-frameworks="true">
-                <pod name="lottie-ios" spec="~> 4.4.0" />
+                <pod name="lottie-ios" spec="~> 4.4" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
Lottie iOS was updated to 4.5.0 https://github.com/airbnb/lottie-ios and this PR is allowing new minor versions of Lottie. 